### PR TITLE
add service to the hid group to access /dev/uhid

### DIFF
--- a/vendor_libs/linux/interface/android.hardware.bluetooth@1.1-service.btlinux.rc
+++ b/vendor_libs/linux/interface/android.hardware.bluetooth@1.1-service.btlinux.rc
@@ -1,6 +1,6 @@
 service btlinux-1.1 /vendor/bin/hw/android.hardware.bluetooth@1.1-service.btlinux
     class hal
     user bluetooth
-    group bluetooth net_admin net_bt_admin
+    group bluetooth net_admin net_bt_admin uhid
     capabilities NET_ADMIN
     disabled


### PR DESCRIPTION
btlinux uses /dev/uhid, add the service to the uhid group